### PR TITLE
feat: add default system instruction config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hasura/promptql",
   "description": "A Node.js SDK allows you to interact with PromptQL API",
-  "version": "0.2.0",
+  "version": "0.3.0-alpha.1",
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/src/client.ts
+++ b/src/client.ts
@@ -138,6 +138,7 @@ export const createPromptQLClient = (
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
+        system_instructions: options.systemInstructions,
         ...rest,
         llm,
         ai_primitives_llm,

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,6 +75,13 @@ export type PromptQLClientConfig = {
   timezone?: string;
 
   /**
+   * Default system instruction prompt.
+   *
+   * @type {?string}
+   */
+  systemInstructions?: string;
+
+  /**
    * Use a custom http client function. Default is fetch.
    *
    * @type {?(


### PR DESCRIPTION
* Added a `systemInstructions` field to the `PromptQLClientConfig` type in `src/types.ts`, allowing users to specify default system instruction prompts.
* Updated the `createPromptQLClient` function in `src/client.ts` to include the `systemInstructions` field in the request payload.