### PR TITLE
fix: race condition in query stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hasura/promptql",
   "description": "A Node.js SDK allows you to interact with PromptQL API",
-  "version": "0.3.0-alpha.1",
+  "version": "0.3.0-alpha.2",
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/src/client.ts
+++ b/src/client.ts
@@ -213,12 +213,13 @@ export const createPromptQLClient = (
           // split chunks to parts and try to decode one by one.
           const rawChunks = tempText.split(DATA_CHUNK_PREFIX);
 
-          rawChunks.forEach(async (chunk, index) => {
+          for (let i = 0; i < rawChunks.length; i++) {
+            const chunk = rawChunks[i]!;
             const line = chunk.trim();
 
             // cache the incomplete chunk to parse later.
             if (line[line.length - 1] !== '}') {
-              incompleteChunk += index > 0 ? `data: ${chunk}` : chunk;
+              incompleteChunk += i > 0 ? `data: ${chunk}` : chunk;
               return;
             }
 
@@ -227,13 +228,13 @@ export const createPromptQLClient = (
             try {
               data = JSON.parse(line);
             } catch (err) {
-              incompleteChunk += index > 0 ? `data: ${line}` : line;
+              incompleteChunk += i > 0 ? `data: ${line}` : line;
             }
 
             if (data) {
               await callback(data);
             }
-          });
+          }
         };
 
         while (true) {


### PR DESCRIPTION
Replaced the `forEach` loop with a `for` loop in the `createPromptQLClient` function to improve clarity and ensure better handling of asynchronous operations. Updated references to the loop index variable accordingly. 