### PR TITLE
Update latest api docs with thread_id

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,26 +1,26 @@
 {
   "name": "@hasura/promptql",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hasura/promptql",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "*"
       },
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
-        "@types/node": "^22.15.3",
-        "@vitest/coverage-v8": "^3.1.2",
+        "@types/node": "^22.15.17",
+        "@vitest/coverage-v8": "^3.1.3",
         "changelogen": "^0.6.1",
-        "openapi-typescript": "^7.6.1",
+        "openapi-typescript": "^7.8.0",
         "typescript": "^5.8.3",
-        "vite": "^6.3.4",
+        "vite": "^6.3.5",
         "vite-plugin-dts": "^4.5.3",
-        "vitest": "^3.1.2"
+        "vitest": "^3.1.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -378,6 +378,8 @@
     },
     "node_modules/@redocly/ajv": {
       "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.2.tgz",
+      "integrity": "sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -393,11 +395,15 @@
     },
     "node_modules/@redocly/config": {
       "version": "0.22.2",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.22.2.tgz",
+      "integrity": "sha512-roRDai8/zr2S9YfmzUfNhKjOF0NdcOIqF7bhf4MVC5UxpjIysDjyudvlAiVbpPHp3eDRWbdzUgtkK1a7YiDNyQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "1.34.2",
+      "version": "1.34.3",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.3.tgz",
+      "integrity": "sha512-3arRdUp1fNx55itnjKiUhO6t4Mf91TsrTIYINDNLAZPS0TPd5YpiXRctwjel0qqWoOOhjA34cZ3m4dksLDFUYg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -416,13 +422,10 @@
         "npm": ">=9.5.0"
       }
     },
-    "node_modules/@redocly/openapi-core/node_modules/colorette": {
-      "version": "1.4.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@redocly/openapi-core/node_modules/minimatch": {
       "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -587,9 +590,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.3.tgz",
-      "integrity": "sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==",
+      "version": "22.15.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.17.tgz",
+      "integrity": "sha512-wIX2aSZL5FE+MR0JlvF87BNVrtFWf6AE6rxSE9X7OwnVvoyCQjpzSRJ+M87se/4QCkCiebQAqrJ0y6fwIyi7nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -597,9 +600,9 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.1.2.tgz",
-      "integrity": "sha512-XDdaDOeaTMAMYW7N63AqoK32sYUWbXnTkC6tEbVcu3RlU1bB9of32T+PGf8KZvxqLNqeXhafDFqCkwpf2+dyaQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.1.3.tgz",
+      "integrity": "sha512-cj76U5gXCl3g88KSnf80kof6+6w+K4BjOflCl7t6yRJPDuCrHtVu0SgNYOUARJOL5TI8RScDbm5x4s1/P9bvpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -620,8 +623,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "3.1.2",
-        "vitest": "3.1.2"
+        "@vitest/browser": "3.1.3",
+        "vitest": "3.1.3"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -630,14 +633,14 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.1.2.tgz",
-      "integrity": "sha512-O8hJgr+zREopCAqWl3uCVaOdqJwZ9qaDwUP7vy3Xigad0phZe9APxKhPcDNqYYi0rX5oMvwJMSCAXY2afqeTSA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.1.3.tgz",
+      "integrity": "sha512-7FTQQuuLKmN1Ig/h+h/GO+44Q1IlglPlR2es4ab7Yvfx+Uk5xsv+Ykk+MEt/M2Yn/xGmzaLKxGw2lgy2bwuYqg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.1.2",
-        "@vitest/utils": "3.1.2",
+        "@vitest/spy": "3.1.3",
+        "@vitest/utils": "3.1.3",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -646,13 +649,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.1.2.tgz",
-      "integrity": "sha512-kOtd6K2lc7SQ0mBqYv/wdGedlqPdM/B38paPY+OwJ1XiNi44w3Fpog82UfOibmHaV9Wod18A09I9SCKLyDMqgw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.1.3.tgz",
+      "integrity": "sha512-PJbLjonJK82uCWHjzgBJZuR7zmAOrSvKk1QBxrennDIgtH4uK0TB1PvYmc0XBCigxxtiAVPfWtAdy4lpz8SQGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.1.2",
+        "@vitest/spy": "3.1.3",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -683,9 +686,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.2.tgz",
-      "integrity": "sha512-R0xAiHuWeDjTSB3kQ3OQpT8Rx3yhdOAIm/JM4axXxnG7Q/fS8XUwggv/A4xzbQA+drYRjzkMnpYnOGAc4oeq8w==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.3.tgz",
+      "integrity": "sha512-i6FDiBeJUGLDKADw2Gb01UtUNb12yyXAqC/mmRWuYl+m/U9GS7s8us5ONmGkGpUUo7/iAYzI2ePVfOZTYvUifA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -696,13 +699,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.1.2.tgz",
-      "integrity": "sha512-bhLib9l4xb4sUMPXnThbnhX2Yi8OutBMA8Yahxa7yavQsFDtwY/jrUZwpKp2XH9DhRFJIeytlyGpXCqZ65nR+g==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.1.3.tgz",
+      "integrity": "sha512-Tae+ogtlNfFei5DggOsSUvkIaSuVywujMj6HzR97AHK6XK8i3BuVyIifWAm/sE3a15lF5RH9yQIrbXYuo0IFyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.1.2",
+        "@vitest/utils": "3.1.3",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -710,13 +713,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.1.2.tgz",
-      "integrity": "sha512-Q1qkpazSF/p4ApZg1vfZSQ5Yw6OCQxVMVrLjslbLFA1hMDrT2uxtqMaw8Tc/jy5DLka1sNs1Y7rBcftMiaSH/Q==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.1.3.tgz",
+      "integrity": "sha512-XVa5OPNTYUsyqG9skuUkFzAeFnEzDp8hQu7kZ0N25B1+6KjGm4hWLtURyBbsIAOekfWQ7Wuz/N/XXzgYO3deWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.1.2",
+        "@vitest/pretty-format": "3.1.3",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -725,9 +728,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.2.tgz",
-      "integrity": "sha512-OEc5fSXMws6sHVe4kOFyDSj/+4MSwst0ib4un0DlcYgQvRuYQ0+M2HyqGaauUMnjq87tmUaMNDxKQx7wNfVqPA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.3.tgz",
+      "integrity": "sha512-x6w+ctOEmEXdWaa6TO4ilb7l9DxPR5bwEb6hILKuxfU1NqWT2mpJD9NJN7t3OTfxmVlOMrvtoFJGdgyzZ605lQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -738,13 +741,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.2.tgz",
-      "integrity": "sha512-5GGd0ytZ7BH3H6JTj9Kw7Prn1Nbg0wZVrIvou+UWxm54d+WoXXgAgjFJ8wn3LdagWLFSEfpPeyYrByZaGEZHLg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.3.tgz",
+      "integrity": "sha512-2Ltrpht4OmHO9+c/nmHtF09HWiyWdworqnHIwjfvDyWjuwKbdkcS9AnhsDn+8E2RM4x++foD1/tNuLPVvWG1Rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.1.2",
+        "@vitest/pretty-format": "3.1.3",
         "loupe": "^3.1.3",
         "tinyrainbow": "^2.0.0"
       },
@@ -846,6 +849,8 @@
     },
     "node_modules/agent-base": {
       "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -948,6 +953,8 @@
     },
     "node_modules/argparse": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
     },
@@ -1115,6 +1122,13 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
       "dev": true,
       "license": "MIT"
     },
@@ -1472,6 +1486,8 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1651,6 +1667,8 @@
     },
     "node_modules/js-levenshtein": {
       "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1664,6 +1682,8 @@
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1904,15 +1924,17 @@
       }
     },
     "node_modules/openapi-typescript": {
-      "version": "7.6.1",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.8.0.tgz",
+      "integrity": "sha512-1EeVWmDzi16A+siQlo/SwSGIT7HwaFAVjvMA7/jG5HMLSnrUOzPL7uSTRZZa4v/LCRxHTApHKtNY6glApEoiUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@redocly/openapi-core": "^1.28.0",
+        "@redocly/openapi-core": "^1.34.3",
         "ansi-colors": "^4.1.3",
         "change-case": "^5.4.4",
-        "parse-json": "^8.1.0",
-        "supports-color": "^9.4.0",
+        "parse-json": "^8.3.0",
+        "supports-color": "^10.0.0",
         "yargs-parser": "^21.1.1"
       },
       "bin": {
@@ -2029,6 +2051,8 @@
     },
     "node_modules/pluralize": {
       "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2368,11 +2392,13 @@
       }
     },
     "node_modules/supports-color": {
-      "version": "9.4.0",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.0.0.tgz",
+      "integrity": "sha512-HRVVSbCCMbj7/kdWF9Q+bbckjBHLtHMEoJWlkmYzzdwhYMkjkOwubLM6t7NbWKjgKamGDrWL1++KrjUO1t9oAQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
@@ -2512,13 +2538,15 @@
     },
     "node_modules/uri-js-replace": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uri-js-replace/-/uri-js-replace-1.0.1.tgz",
+      "integrity": "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.4.tgz",
-      "integrity": "sha512-BiReIiMS2fyFqbqNT/Qqt4CVITDU9M9vE+DKcVAsB+ZV0wvTKd+3hMbkpxz1b+NmEDMegpVbisKiAZOnvO92Sw==",
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
+      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2591,15 +2619,15 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.1.2.tgz",
-      "integrity": "sha512-/8iMryv46J3aK13iUXsei5G/A3CUlW4665THCPS+K8xAaqrVWiGB4RfXMQXCLjpK9P2eK//BczrVkn5JLAk6DA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.1.3.tgz",
+      "integrity": "sha512-uHV4plJ2IxCl4u1up1FQRrqclylKAogbtBfOTwcuJ28xFi+89PZ57BRh+naIRvH70HPwxy5QHYzg1OrEaC7AbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
         "debug": "^4.4.0",
-        "es-module-lexer": "^1.6.0",
+        "es-module-lexer": "^1.7.0",
         "pathe": "^2.0.3",
         "vite": "^5.0.0 || ^6.0.0"
       },
@@ -2639,19 +2667,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.1.2.tgz",
-      "integrity": "sha512-WaxpJe092ID1C0mr+LH9MmNrhfzi8I65EX/NRU/Ld016KqQNRgxSOlGNP1hHN+a/F8L15Mh8klwaF77zR3GeDQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.1.3.tgz",
+      "integrity": "sha512-188iM4hAHQ0km23TN/adso1q5hhwKqUpv+Sd6p5sOuh6FhQnRNW3IsiIpvxqahtBabsJ2SLZgmGSpcYK4wQYJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "3.1.2",
-        "@vitest/mocker": "3.1.2",
-        "@vitest/pretty-format": "^3.1.2",
-        "@vitest/runner": "3.1.2",
-        "@vitest/snapshot": "3.1.2",
-        "@vitest/spy": "3.1.2",
-        "@vitest/utils": "3.1.2",
+        "@vitest/expect": "3.1.3",
+        "@vitest/mocker": "3.1.3",
+        "@vitest/pretty-format": "^3.1.3",
+        "@vitest/runner": "3.1.3",
+        "@vitest/snapshot": "3.1.3",
+        "@vitest/spy": "3.1.3",
+        "@vitest/utils": "3.1.3",
         "chai": "^5.2.0",
         "debug": "^4.4.0",
         "expect-type": "^1.2.1",
@@ -2664,7 +2692,7 @@
         "tinypool": "^1.0.2",
         "tinyrainbow": "^2.0.0",
         "vite": "^5.0.0 || ^6.0.0",
-        "vite-node": "3.1.2",
+        "vite-node": "3.1.3",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -2680,8 +2708,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.1.2",
-        "@vitest/ui": "3.1.2",
+        "@vitest/browser": "3.1.3",
+        "@vitest/ui": "3.1.3",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -2841,6 +2869,8 @@
     },
     "node_modules/yaml-ast-parser": {
       "version": "0.0.43",
+      "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
+      "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==",
       "dev": true,
       "license": "Apache-2.0"
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hasura/promptql",
   "description": "A Node.js SDK allows you to interact with PromptQL API",
-  "version": "0.3.0-alpha.2",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"
@@ -37,13 +37,13 @@
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
-    "@types/node": "^22.15.3",
-    "@vitest/coverage-v8": "^3.1.2",
+    "@types/node": "^22.15.17",
+    "@vitest/coverage-v8": "^3.1.3",
     "changelogen": "^0.6.1",
-    "openapi-typescript": "^7.6.1",
+    "openapi-typescript": "^7.8.0",
     "typescript": "^5.8.3",
-    "vite": "^6.3.4",
+    "vite": "^6.3.5",
     "vite-plugin-dts": "^4.5.3",
-    "vitest": "^3.1.2"
+    "vitest": "^3.1.3"
   }
 }

--- a/src/promptql.d.ts
+++ b/src/promptql.d.ts
@@ -443,6 +443,21 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["QueryResponse"];
+                    /** @example data: {"message":"Let me try to store an artifact","plan":null,"code":null,"code_output":null,"code_error":null,"type":"assistant_action_chunk","index":0}
+                     *
+                     *     data: {"message":null,"plan":"- Store an artifact with sample data","code":null,"code_output":null,"code_error":null,"type":"assistant_action_chunk","index":0}
+                     *
+                     *     data: {"message":null,"plan":null,"code":"executor.store_artitfact('test', 'Test artifact', 'table', [{'foo':'bar'}])","code_output":null,"code_error":null,"type":"assistant_action_chunk","index":0}
+                     *
+                     *     data: {"message":null,"plan":null,"code":null,"code_output":"Artifact stored","code_error":null,"type":"assistant_action_chunk","index":0}
+                     *
+                     *     data: {"type":"artifact_update_chunk","artifact":{"identifier":"test","title":"Test Artifact","artifact_type":"table","data":[{"foo":"bar"}]}}
+                     *
+                     *     data: {"message":"Your artifact is <artifact","plan":null,"code":null,"code_output":null,"code_error":null,"type":"assistant_action_chunk","index":1}
+                     *
+                     *     data: {"message":" identifier='test'/>","plan":null,"code":null,"code_output":null,"code_error":null,"type":"assistant_action_chunk","index":1}
+                     *
+                     *      */
                     "text/event-stream": components["schemas"]["QueryResponseChunk"];
                 };
             };

--- a/src/promptql.d.ts
+++ b/src/promptql.d.ts
@@ -70,8 +70,8 @@ export type components = {
             /** Api Key */
             api_key: string;
         };
-        /** AssistantAction */
-        AssistantAction: {
+        /** ApiThreadAssistantAction */
+        ApiThreadAssistantAction: {
             /** Message */
             message?: string | null;
             /** Plan */
@@ -82,6 +82,17 @@ export type components = {
             code_output?: string | null;
             /** Code Error */
             code_error?: string | null;
+        };
+        /** ApiThreadInteraction */
+        ApiThreadInteraction: {
+            user_message: components["schemas"]["ApiThreadUserMessage"];
+            /** Assistant Actions */
+            assistant_actions?: components["schemas"]["ApiThreadAssistantAction"][];
+        };
+        /** ApiThreadUserMessage */
+        ApiThreadUserMessage: {
+            /** Text */
+            text: string;
         };
         /** DdnConfig */
         DdnConfig: {
@@ -125,12 +136,6 @@ export type components = {
              * @enum {string}
              */
             provider: "hasura";
-        };
-        /** Interaction */
-        Interaction: {
-            user_message: components["schemas"]["UserMessage"];
-            /** Assistant Actions */
-            assistant_actions?: components["schemas"]["AssistantAction"][];
         };
         /** LlmUsage */
         LlmUsage: {
@@ -195,14 +200,19 @@ export type components = {
              */
             timezone: string;
             /** Interactions */
-            interactions: components["schemas"]["Interaction"][];
+            interactions: components["schemas"]["ApiThreadInteraction"][];
             /** Stream */
             stream: boolean;
         };
         /** QueryResponse */
         QueryResponse: {
+            /**
+             * Thread Id
+             * Format: uuid
+             */
+            thread_id: string;
             /** Assistant Actions */
-            assistant_actions: components["schemas"]["AssistantAction"][];
+            assistant_actions: components["schemas"]["ApiThreadAssistantAction"][];
             /**
              * Modified Artifacts
              * @description List of artifacts created or updated in this request. May contain duplicate artifact identifiers.
@@ -242,11 +252,6 @@ export type components = {
             /** Data */
             data: string;
         };
-        /** UserMessage */
-        UserMessage: {
-            /** Text */
-            text: string;
-        };
         /** ValidationError */
         ValidationError: {
             /** Location */
@@ -284,7 +289,7 @@ export type components = {
             /** Visualization Data */
             visualization_data: unknown;
         };
-        QueryResponseChunk: components["schemas"]["AssistantActionChunk"] | components["schemas"]["ArtifactUpdateChunk"] | components["schemas"]["ErrorChunk"];
+        QueryResponseChunk: components["schemas"]["ThreadMetadataChunk"] | components["schemas"]["AssistantActionChunk"] | components["schemas"]["ArtifactUpdateChunk"] | components["schemas"]["ErrorChunk"];
         /** ArtifactUpdateChunk */
         ArtifactUpdateChunk: {
             /**
@@ -340,6 +345,19 @@ export type components = {
             /** Error */
             error: string;
         };
+        /** ThreadMetadataChunk */
+        ThreadMetadataChunk: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "thread_metadata_chunk";
+            /**
+             * Thread Id
+             * Format: uuid
+             */
+            thread_id: string;
+        };
     };
     responses: never;
     parameters: never;
@@ -349,19 +367,19 @@ export type components = {
 };
 export type ApiAnthropicConfig = components['schemas']['ApiAnthropicConfig'];
 export type ApiOpenAiConfig = components['schemas']['ApiOpenAIConfig'];
-export type AssistantAction = components['schemas']['AssistantAction'];
+export type ApiThreadAssistantAction = components['schemas']['ApiThreadAssistantAction'];
+export type ApiThreadInteraction = components['schemas']['ApiThreadInteraction'];
+export type ApiThreadUserMessage = components['schemas']['ApiThreadUserMessage'];
 export type DdnConfig = components['schemas']['DdnConfig'];
 export type ExecuteRequest = components['schemas']['ExecuteRequest'];
 export type HttpValidationError = components['schemas']['HTTPValidationError'];
 export type HasuraLlmConfig = components['schemas']['HasuraLlmConfig'];
-export type Interaction = components['schemas']['Interaction'];
 export type LlmUsage = components['schemas']['LlmUsage'];
 export type PromptQlExecutionResult = components['schemas']['PromptQlExecutionResult'];
 export type QueryRequest = components['schemas']['QueryRequest'];
 export type QueryResponse = components['schemas']['QueryResponse'];
 export type TableArtifact = components['schemas']['TableArtifact'];
 export type TextArtifact = components['schemas']['TextArtifact'];
-export type UserMessage = components['schemas']['UserMessage'];
 export type ValidationError = components['schemas']['ValidationError'];
 export type VisualizationArtifact = components['schemas']['VisualizationArtifact'];
 export type VisualizationArtifactData = components['schemas']['VisualizationArtifactData'];
@@ -369,6 +387,7 @@ export type QueryResponseChunk = components['schemas']['QueryResponseChunk'];
 export type ArtifactUpdateChunk = components['schemas']['ArtifactUpdateChunk'];
 export type AssistantActionChunk = components['schemas']['AssistantActionChunk'];
 export type ErrorChunk = components['schemas']['ErrorChunk'];
+export type ThreadMetadataChunk = components['schemas']['ThreadMetadataChunk'];
 export type $defs = Record<string, never>;
 export interface operations {
     execute_program_execute_program_post: {

--- a/src/query-chunk.test.ts
+++ b/src/query-chunk.test.ts
@@ -4,6 +4,7 @@ import { createQueryChunks } from './query-chunks';
 
 test('QueryChunks', (t) => {
   const fixtures = [
+    '{"type":"thread_metadata_chunk","thread_id":"9a6c9bc2-8005-4cf7-ba93-22edf90fa490"}',
     '{"message":"I\'ll re","plan":null,"code":null,"code_output":null,"code_error":null,"type":"assistant_action_chunk","index":0}',
     '{"message":"trieve the list of custome","plan":null,"code":null,"code_output":null,"code_error":null,"type":"assistant_action_chunk","index":0}',
     '{"message":"rs for you.","plan":null,"code":null,"code_output":null,"code_error":null,"type":"assistant_action_chunk","index":0}',
@@ -32,6 +33,7 @@ test('QueryChunks', (t) => {
     '{"message":" full data so I must not make up observations\' />","plan":null,"code":null,"code_output":null,"code_error":null,"type":"assistant_action_chunk","index":1}',
   ];
   const expected: QueryResponse = {
+    thread_id: '9a6c9bc2-8005-4cf7-ba93-22edf90fa490',
     assistant_actions: [
       {
         code: 'sql = """\nSELECT id, name \nFROM customers()\nORDER BY name\n"""\n\ncustomers = executor.run_sql(sql)\n\nif len(customers) == 0:\n    executor.print("No customers found.")\nelse:\n    executor.store_artifact(\n        \'customer_list\',\n        \'List of Customers\',\n        \'table\',\n        customers\n    )',


### PR DESCRIPTION
This pull request introduces support for handling thread metadata in the `QueryChunks` module by adding a `thread_id` property and updating related data structures and methods. The changes ensure that thread metadata can be processed, stored, and retrieved alongside other query data.

### Type updates:

* Replaced `AssistantAction` with `ApiThreadAssistantAction` in relevant types and variables to accommodate the new `thread_id` property. (`src/query-chunks.ts`: [[1]](diffhunk://#diff-c86a12c28b8bd32e19157d7e00d2263a37ea6e45dcf05bb724a384de86bba2caL2-R2) [[2]](diffhunk://#diff-c86a12c28b8bd32e19157d7e00d2263a37ea6e45dcf05bb724a384de86bba2caL203-R212)
